### PR TITLE
fix typo in node maintenance

### DIFF
--- a/README.org
+++ b/README.org
@@ -188,8 +188,8 @@ File me [[https://github.com/dennyzhang/cheatsheet.dennyzhang.com/issues][Issues
 ** Node Maintenance
 | Name                                      | Command                       |
 |-------------------------------------------+-------------------------------|
-| Mark node as unschedulable                | =kubectl cordon $NDOE_NAME=   |
-| Mark node as schedulable                  | =kubectl uncordon $NDOE_NAME= |
+| Mark node as unschedulable                | =kubectl cordon $NODE_NAME=   |
+| Mark node as schedulable                  | =kubectl uncordon $NODE_NAME= |
 | Drain node in preparation for maintenance | =kubectl drain $NODE_NAME=    |
 ** Namespace & Security
 | Name                          | Command                                                                                             |


### PR DESCRIPTION
Fixed a small typos that was bothering me 😄 

I also noticed that many snippets of code that includes the `=` can't be formatted properly

Would it be possible to support markdown inline code format with the backtick ?

```
`
```

https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code

best regards, Pierre